### PR TITLE
Make "Screen Options" not white on white

### DIFF
--- a/assets/styles/admin/partials/meta.scss
+++ b/assets/styles/admin/partials/meta.scss
@@ -53,6 +53,7 @@
   background: $primary;
 
   .show-settings {
+    background: $primary;
     color: $white;
     box-shadow: none;
 


### PR DESCRIPTION
On the latest WP, the "Screen Options" and "Help" toggles at the top right have a white background, which makes them unreadable with this white text

`wp-admin/css/common.css:1688` rule for `#screen-meta-links .show-settings { background: #fff; }`